### PR TITLE
Update for most recent molecule and ansible

### DIFF
--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -1,13 +1,4 @@
 ---
-# rsyslog is already installed on the AMIs we are using
-- name: Create
-  hosts: all
-  tasks:
-    - name: Install rsyslog
-      package:
-        name: rsyslog
-        state: present
-
 - name: Converge
   hosts: all
   roles:

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -1,0 +1,14 @@
+---
+# rsyslog is installed anywhere we would be applying this Ansible role
+- name: Prepare
+  hosts: all
+  tasks:
+    - name: Temporary workaround for ansible/ansible#56583
+      set_fact:
+        ansible_facts:
+          pkg_mgr: yum
+      when: ansible_os_family == "RedHat" and ansible_distribution == "Amazon"
+    - name: Install rsyslog
+      package:
+        name: rsyslog
+        state: present

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -3,6 +3,8 @@
 - name: Prepare
   hosts: all
   tasks:
+    # This is required temporarily, because of
+    # https://github.com/ansible/ansible/issues/56583
     - name: Temporary workaround for ansible/ansible#56583
       set_fact:
         ansible_facts:

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,11 @@
 docker # Needed for molecule to work correctly
-molecule
+flake8
+# Temporarily use the latest molecule from master.  The latest release
+# of molecule does not play well with ansible 2.8.  We will revert
+# this once a new release comes out.
+#
+# Also install flake8, since it appears to be missing from the
+# dependencies for the bleeding edge molecule.
+# molecule
+git+https://github.com/ansible/molecule.git#egg=molecule
 pre-commit

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,12 @@
 ---
 # tasks file for logrotate
 
+- name: Temporary workaround for ansible/ansible#56583
+  set_fact:
+    ansible_facts:
+      pkg_mgr: yum
+  when: ansible_os_family == "RedHat" and ansible_distribution == "Amazon"
+
 - name: Install logrotate
   package:
     name: logrotate


### PR DESCRIPTION
* Copy over `requirements-test.txt` from cisagov/skeleton-ansible-role so that a bleeding-edge version of molecule is installed.
* Move the installation of rsyslog from `playbook.yml` to `prepare.yml` to better agree with what we do in other Ansible roles.
* Manually set the `pkg_mgr` Ansible fact when using Amazon Linux to work around ansible/ansible#56583.